### PR TITLE
Include full-width color mixin

### DIFF
--- a/dist/_scut.scss
+++ b/dist/_scut.scss
@@ -448,6 +448,67 @@ http://davidtheclark.github.io/scut/#fonticon_label
 
 
 /*==========================
+SCUT FULL-WIDTH COLOR
+
+Depends on html and body having overflow-x set to hidden.
+
+Example:
+body, html {
+  overflow-x: hidden;
+}
+
+==========================*/
+
+@mixin scut-full-color (
+  $center-background: white, 
+  $left-background: red, 
+  $right-background: blue
+) {
+  
+  @extend %full-width-content;
+  background-color: $center-background;
+
+  &:before, &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 99999px;
+  }
+  
+  &:after {
+    background-color: $left-background;
+    right: 100%; 
+  }
+
+  &:before {
+    background-color: $right-background;
+    left: 100%;
+  }
+}
+
+%full-width-content {
+  
+  position: relative;
+  display: inline-block;
+  width: 100%;
+
+  &:before, &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 99999px;
+  }
+  &:after {
+    right: 100%; 
+  }
+  &:before {
+    left: 100%;
+  }
+}`
+
+/*==========================
 SCUT LIST: DIVIDED
 http://davidtheclark.github.io/scut/#list_divided
 

--- a/src/layout/_full-width-color.scss
+++ b/src/layout/_full-width-color.scss
@@ -1,0 +1,60 @@
+/*==========================
+SCUT FULL-WIDTH COLOR
+
+Depends on html and body having overflow-x set to hidden.
+
+Example:
+body, html {
+  overflow-x: hidden;
+}
+
+==========================*/
+
+@mixin scut-full-color (
+  $center-background: white, 
+  $left-background: red, 
+  $right-background: blue
+) {
+  
+  @extend %full-width-content;
+  background-color: $center-background;
+
+  &:before, &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 99999px;
+  }
+  
+  &:after {
+    background-color: $left-background;
+    right: 100%; 
+  }
+
+  &:before {
+    background-color: $right-background;
+    left: 100%;
+  }
+}
+
+%full-width-content {
+  
+  position: relative;
+  display: inline-block;
+  width: 100%;
+
+  &:before, &:after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 99999px;
+  }
+  &:after {
+    right: 100%; 
+  }
+  &:before {
+    left: 100%;
+  }
+}`


### PR DESCRIPTION
This lets the user define a full-width background color [within a max-width container](http://css-tricks.com/full-browser-width-bars/). I've also created and documented a [nifty mixin for full-width imagery](http://www.commercekitchen.com/2013/10/full-width-backgrounds-scss/). I can send another pull request for this if you're interested.

Finally, I didn't get the test environment spun up yet, but this is [functional on CodePen](http://codepen.io/mragray/pen/BKlIp).
