### PR TITLE
Bug fix help.hbs

### DIFF
--- a/docs/dev/assemble/partials/help.hbs
+++ b/docs/dev/assemble/partials/help.hbs
@@ -3,7 +3,7 @@
   <section id="help-{{term}}" class="help-content js-help-modal">
     <div class="scut-inner">
       {{#markdown}}{{{text}}}{{/markdown}}
-      <button class="js-help-btn help-close" data-dir="close" data-term="{{term}}}">close</button>
+      <button class="js-help-btn help-close" data-dir="close" data-term="{{term}}">close</button>
     </div>
   </section>
   {{/each}}


### PR DESCRIPTION
Removing extra curly bracket in `data-term="{{term}}"`, causing error on `grunt init`. Error code:

```
Running "assemble:docsDev" (assemble) task
Assembling docs/dev/index.html ERROR
Warning: Parse error on line 6:
...e" data-term="{{term}}}">close</button>
-----------------------^
Expecting 'CLOSE', got 'CLOSE_UNESCAPED' Use --force to continue.

Aborted due to warnings.
```
