### PR TITLE
Adding scut-pseudo with shortcuts for display and position

### DIFF
--- a/src/layout/_pseudo.scss
+++ b/src/layout/_pseudo.scss
@@ -1,0 +1,40 @@
+@mixin scut-pseudo (
+  $display,
+  $position,
+  $content: ""
+) {
+
+  content: $content;
+
+  @if ($display != "") {
+    display: $display;
+  }
+
+  @if ($position != "") {
+    position: $position;
+  }
+
+  @content;
+
+}
+
+%scut-pseudo-absolute {
+  @include scut-pseudo(block, absolute);
+}
+
+%scut-pseudo-relative {
+  @include scut-pseudo(block, relative);
+}
+
+%scut-pseudo-block {
+  @include scut-pseudo(block);
+}
+
+%scut-pseudo-inline-block {
+  @include scut-pseudo(inline-block);
+}
+
+// for inline elements
+%scut-pseudo { 
+  @include scut-pseudo;
+}


### PR DESCRIPTION
I'm trying an alternative approach of #113 based on how I often use pseudo-elements. What I usually do is use an `@extend` call for a simple combination of `content` and `position` or `display`, making it so these commonly paired properties aren't thrown all over the stylesheet.

This pull request differs from #113 in that it's not meant to create a `:before` or `:after` rule in the stylesheet - these mixins/extends are meant to be used within an existing one. This means that these utilities can much more easily be used via `@extend`. This is not to say that you couldn't provide optional `@content` inside the mixin if you wanted to, but you'd still have to place it inside a pseudo-element rule.

If you think I should rework this to include the `:before` or `:after` rule as well, I could do that. The pro is that for absolutely positioned pseudo-elements I could provide an automatic `position: relative;` for the parent element, but the con is that adding another parameter might mess with the simple names for the extends - there would have to be names like `%scut-pseudo-before-absolute` and `%scut-pseudo-after-absolute` which doesn't seem especially helpful to me.

If you think this is helpful, I'd be happy to write up some documentation on it.
