### PR TITLE
Border-radius shorthand for easy rounded corners

### DIFF
--- a/src/general/_round-corner.scss
+++ b/src/general/_round-corner.scss
@@ -1,0 +1,15 @@
+@mixin round-corner (
+  $corners: 0 0 0 0
+) {
+
+  $top-left: nth($corners, 1);
+  $top-right: nth($corners, 2);
+  $bottom-right: nth($corners, 3);
+  $bottom-left: nth($corners, 4);
+
+  border-top-left-radius: $top-left;
+  border-top-right-radius: $top-right;
+  border-bottom-right-radius: $bottom-right;
+  border-bottom-left-radius: $bottom-left;
+
+}


### PR DESCRIPTION
Demo http://sassmeister.com/gist/881e68672287d08817dc

- According to some places `border-radius` shorthand is not supported by Webkit.
- According to [CanIUse](http://caniuse.com/#search=border-ra) Samsung Galaxy S4 with Android 4.2 does not support the `border-radius` shorthand

This mixin expands shorthand into longhand.