### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "style"
   ],
   "license": "MIT",
-  "scripts": {
-    "postinstall": "bower install"
-  },
   "devDependencies": {
     "assemble": "^0.4.42",
     "grunt": "^0.4.5",


### PR DESCRIPTION
npm: `postinstall` fails because there's no bower.json