### PR TITLE
Added asterisk and hashtag to characters

### DIFF
--- a/src/typography/_characters.scss
+++ b/src/typography/_characters.scss
@@ -61,6 +61,10 @@ $scut-hellip: "\2026";
 $scut-vellip: "\22EE";
 // midline horizontal ellipsis
 $scut-midhellip: "\22EF";
+// asterisk
+$scut-asterisk: "\002A";
+// hashtag
+$scut-hashtag: "\0023";
 
 // up-pointing triangle
 $scut-utri: "\25b2";


### PR DESCRIPTION
I've added the asterisk and hashtag characters, I use both in my projects and figured others might find them useful too. Here's a couple of examples for using these characters:

Prepending a hashtag to a tag link.

```scss
a[rel="tag"],
.tag {
  &::before {
    content: $scut-hashtag;
  }
}
```

Appending an asterisk to a required form field label.

```scss
label {
  &.required {
    &::after {
      color: $color-danger;
      content: $scut-asterisk;
    }
  }
}
```


