### PR TITLE
Add the repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "style"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/davidtheclark/scut"
+  },
   "devDependencies": {
     "assemble": "^0.4.42",
     "grunt": "^0.4.5",


### PR DESCRIPTION
When consuming Scut directly from NPM it generates a warning about the repository missing. This makes that go away. :smile: 