### PR TITLE
[RFR] Removed -moz-box-sizing in scut-reset-border-box

### DIFF
--- a/src/general/_reset.scss
+++ b/src/general/_reset.scss
@@ -1,11 +1,9 @@
 @mixin scut-reset-border-box {
   // Make everything a border-box, because why not?
   html {
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
   }
   *, *:before, *:after {
-    -moz-box-sizing: inherit;
     box-sizing: inherit;
   }
 }


### PR DESCRIPTION
There is no need to prefix this property in Firefox since version 29: http://caniuse.com/#search=box-sizing. :)