### PR TITLE
Unquote vcenter inner selectors - Fixes #187

### DIFF
--- a/dist/_scut.scss
+++ b/dist/_scut.scss
@@ -1127,6 +1127,7 @@ $scut-rem-base: 16 !default;
 
   $inner: if(length($inner) == 0, ".scut-inner", $inner);
   @each $cell-selector in $inner {
+    $cell-selector: unquote($cell-selector);
     & > #{$cell-selector} {
       display: inline-block;
       vertical-align: middle;
@@ -1155,6 +1156,7 @@ $scut-rem-base: 16 !default;
 
   $inner: if(length($inner) == 0, ".scut-inner", $inner);
   @each $cell-selector in $inner {
+    $cell-selector: unquote($cell-selector);
     & > #{$cell-selector} {
       display: table-cell;
       vertical-align: middle;

--- a/src/layout/_vcenter-ib.scss
+++ b/src/layout/_vcenter-ib.scss
@@ -19,6 +19,7 @@
 
   $inner: if(length($inner) == 0, ".scut-inner", $inner);
   @each $cell-selector in $inner {
+    $cell-selector: unquote($cell-selector);
     & > #{$cell-selector} {
       display: inline-block;
       vertical-align: middle;

--- a/src/layout/_vcenter-td.scss
+++ b/src/layout/_vcenter-td.scss
@@ -6,6 +6,7 @@
 
   $inner: if(length($inner) == 0, ".scut-inner", $inner);
   @each $cell-selector in $inner {
+    $cell-selector: unquote($cell-selector);
     & > #{$cell-selector} {
       display: table-cell;
       vertical-align: middle;


### PR DESCRIPTION
I'm not sure what caused issue #187 but I am also getting quotes around the inner selectors for the `vcenter` mixins.

Using the `unquote()` function fixes the issue.

It may be an issue elsewhere but I have not noticed it yet.