### PR TITLE
Add scut-link-unstyled mixin

### DIFF
--- a/docs/content/entries/link-unstyled.md
+++ b/docs/content/entries/link-unstyled.md
@@ -1,0 +1,14 @@
+---
+name: "link: unstyled"
+slug: link-unstyled
+summary: Remove default styling from a link (anchor tag).
+type: mixin
+categories:
+  - layout
+args:
+example:
+  html: |
+    <a class="eg-link-unstyled" href="//google.com">Unstyled Link</a>
+---
+
+Specifically, remove `text-decoration`, and set `color: inherit`.

--- a/docs/content/example-styles/link-unstyled.scss
+++ b/docs/content/example-styles/link-unstyled.scss
@@ -1,0 +1,14 @@
+/* import start */
+@import "../../../dist/scut";
+@import "example-variables";
+/* import end */
+
+/* hidden rules */
+/* end hidden rules */
+
+/* example start */
+.eg-link-unstyled {
+  @include scut-link-unstyled;
+  // or @extend %scut-link-unstyled;
+}
+/* example end */

--- a/src/layout/_link-unstyled.scss
+++ b/src/layout/_link-unstyled.scss
@@ -1,0 +1,14 @@
+// SCUT LINK UNSTYLED
+// http://davidtheclark.github.io/scut/#link-unstyled
+
+// Depends on `scut-strip-unit`.
+@mixin scut-link-unstyled() {
+
+  text-decoration: none;
+  color: inherit;
+
+}
+
+%scut-link-unstyled {
+  @include scut-link-unstyled();
+}


### PR DESCRIPTION
This mixin removes text-decoration from an anchor tag, and make its color inherited.

This PR solves issue https://github.com/davidtheclark/scut/issues/191

I wouldn't mind someone reviewing this, especially for the docs I added, as I wasn't able to successfully build them locally using Assemble. Was getting:

```
Running "assemble:docsDev" (assemble) task
Assembling docs/dist/absolute.html ERROR
Warning: Unable to read "./docs/content/example-styles/processed/absolute.scss" file (Error code: ENOENT). Use --force to continue.
```