### PR TITLE
Add eyeglass needed version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "description": "A collection of Sass utilities to ease and improve our implementations of common style-code patterns.",
   "main": "dist/_scut.scss",
   "eyeglass": {
-    "exports": "lib/eyeglass-exports.js"
+    "exports": "lib/eyeglass-exports.js",
+    "needs": "^0.7.1"
   },
   "keywords": [
     "SCSS",


### PR DESCRIPTION
Add eyeglass needed version to get rid of the warning:
````
The following modules did not declare an eyeglass version:
scut
Please add the following to the module's package.json:
  "eyeglass": { "needs": "^0.7.1" }
````
Fixes #194