### PR TITLE
Remove the input element selectors from the button reset

### DIFF
--- a/src/general/_reset.scss
+++ b/src/general/_reset.scss
@@ -59,9 +59,9 @@
 @mixin scut-reset-button {
   // Reset default button styles, which are never used.
   button,
-  input[type="button"],
-  input[type="submit"],
-  input[type="reset"] {
+  [type="button"],
+  [type="submit"],
+  [type="reset"] {
     background: transparent;
     border: 0;
     color: inherit;


### PR DESCRIPTION
The button reset, while very helpful, has an unfortunate amount of specificity when using it with an `input` element. Because the element + attribute selector is more specific than just a class selector, simply adding a class of `Button` to an `input` is not enough to override the reset.

However, since attribute selectors and class selectors have the same specificity and only `button` and `input` elements have the types `button`, `submit`, and `reset`, reducing the reset to just the attribute selectors should fix this issue.