### PR TITLE
Update eyeglass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "dist/_scut.scss",
   "eyeglass": {
     "exports": "lib/eyeglass-exports.js",
-    "needs": "^0.7.1"
+    "needs": "^0.7.1 || ^1"
   },
   "keywords": [
     "SCSS",


### PR DESCRIPTION
This makes it possible to use scut with the latest versions of eyeglass.  Since 1.0.0, eyeglass uses semver, so it shouldn't be necessary to change this again as long as the API remains stable.