### PR TITLE
[1.4.1] Fix breaking change: slash as division

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.1
+- Fixed [`slash as division`](https://sass-lang.com/documentation/breaking-changes/slash-div) deprecation.
+
 ## 1.4.0
 
 - Added common currencies to scut-characters

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Scut",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "homepage": "http://davidtheclark.github.io/scut/",
   "authors": [
     "David Clark <david.dave.clark@gmail.com>"

--- a/dist/_scut.scss
+++ b/dist/_scut.scss
@@ -1,7 +1,7 @@
 /*
 * Scut, a collection of Sass utilities
 * to ease and improve our implementations of common style-code patterns.
-* v1.4.0
+* v1.4.1
 * Docs at http://davidtheclark.github.io/scut
 */
 

--- a/dist/_scut.scss
+++ b/dist/_scut.scss
@@ -5,6 +5,8 @@
 * Docs at http://davidtheclark.github.io/scut
 */
 
+@use "sass:math";
+
 @mixin scut-clearfix {
 
   &:after {
@@ -98,7 +100,7 @@
   $num
 ) {
 
-  @return $num / ($num * 0 + 1);
+  @return math.div($num, $num * 0 + 1);
 
 }
 // Depends on `scut-strip-unit`.
@@ -118,7 +120,7 @@ $scut-em-base: 16 !default;
 
   $em-vals: ();
   @each $val in $pixels {
-    $val-in-ems: (scut-strip-unit($val) / $divisor) * 1em;
+    $val-in-ems: math.div(scut-strip-unit($val), $divisor) * 1em;
     $em-vals: append($em-vals, $val-in-ems);
   }
 
@@ -142,7 +144,7 @@ $scut-rem-base: 16 !default;
 
   $rem-vals: ();
   @each $val in $pixels {
-    $val-in-rems: scut-strip-unit($val) / $scut-rem-base * 1rem;
+    $val-in-rems: math.div(scut-strip-unit($val), $scut-rem-base) * 1rem;
     $rem-vals: append($rem-vals, $val-in-rems);
   }
 
@@ -204,7 +206,7 @@ $scut-rem-base: 16 !default;
     // If user wants to inherit the color,
     // take advantage of the fact that border
     // color defaults to the text color of the element.
-    border-width: $size / 2;
+    border-width: $size * 0.5;
     border-style: solid;
     height: 0;
     width: 0;
@@ -279,7 +281,7 @@ $scut-rem-base: 16 !default;
   $ratio: 1.3
 ) {
 
-  @media (-o-min-device-pixel-ratio: ($ratio / 1)),
+  @media (-o-min-device-pixel-ratio: math.div($ratio, 1)),
          (-webkit-min-device-pixel-ratio: $ratio),
          (min-resolution: (round(96 * $ratio) * 1dpi)) {
     @content;
@@ -523,17 +525,17 @@ $scut-rem-base: 16 !default;
   @if ($direction == up) or ($direction == down) {
     // For up and down, width gets two borders but height only one,
     // so divide second border-width value by 2
-    $border-widths: $height ($width / 2);
+    $border-widths: $height ($width * 0.5);
   }
   @else if ($direction == right) or ($direction == left) {
     // For right and left, height gets two borders but width only one,
     // so divide first border-width value by 2
-    $border-widths: ($height / 2) $width;
+    $border-widths: ($height * 0.5) $width;
   }
   @else {
     // For right triangles (the rest), both sides get two borders,
     // so divide both by 2
-    $border-widths: ($height / 2) ($width / 2);
+    $border-widths: ($height * 0.5) ($width * 0.5);
   }
 
   border-width: $border-widths;
@@ -608,13 +610,13 @@ $scut-rem-base: 16 !default;
   @if $width != n {
     width: $width;
     left: 50%;
-    margin-left: (-$width / 2);
+    margin-left: (-$width * 0.5);
   }
 
   @if $height != n {
     height: $height;
     top: 50%;
-    margin-top: (-$height / 2);
+    margin-top: (-$height * 0.5);
   }
 
 }
@@ -1023,7 +1025,7 @@ $scut-rem-base: 16 !default;
     content: "";
     display: block;
     height: 0;
-    padding-top: (1 / $ratio) * 100%;
+    padding-top: math.div(1, $ratio) * 100%;
   }
 
 }

--- a/docs/content/data.yml
+++ b/docs/content/data.yml
@@ -1,4 +1,4 @@
-"version": "1.4.0"
+"version": "1.4.1"
 github-url: "https://github.com/davidtheclark/scut/blob/v"
 github-home: "https://github.com/davidtheclark/scut"
 codepen-url: "http://codepen.io/davidtheclark/pen/FhqGc"

--- a/docs/content/example-styles/ratio-box.scss
+++ b/docs/content/example-styles/ratio-box.scss
@@ -1,4 +1,6 @@
 /* import start */
+@use "sass:math";
+
 @import "../../../dist/scut";
 @import "example-variables";
 /* import end */
@@ -24,11 +26,11 @@
 }
 .eg-ratio-3 {
   width: 15em;
-  @include scut-ratio-box(16/9);
+  @include scut-ratio-box(math.div(16, 9));
 }
 .eg-ratio-4 {
   width: 7em;
-  @include scut-ratio-box(16/9);
+  @include scut-ratio-box(math.div(16, 9));
 }
 .eg-ratio-inner {
   position: absolute;

--- a/docs/dev/scss/_examples.scss
+++ b/docs/dev/scss/_examples.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $eg-dark: #002834;
 $eg-light: #9AE9FF;
 $eg-muted: #CCCCCC;
@@ -630,11 +632,11 @@ $scut-em-base: 16;
 }
 .eg-ratio-3 {
   width: 15em;
-  @include scut-ratio-box(16/9);
+  @include scut-ratio-box(math.div(16, 9));
 }
 .eg-ratio-4 {
   width: 7em;
-  @include scut-ratio-box(16/9);
+  @include scut-ratio-box(math.div(16, 9));
 }
 .eg-ratio-inner {
   position: absolute;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-var currentVersion = '1.4.0';
+var currentVersion = '1.4.1';
 
 var moment = require('moment');
 var runSequence = require('run-sequence');

--- a/lib/scut.rb
+++ b/lib/scut.rb
@@ -5,6 +5,6 @@ stylesheets_dir = File.join(base_directory, 'dist')
 Compass::Frameworks.register('Scut', :stylesheets_directory => stylesheets_dir)
 
 module Scut
-  VERSION = "1.4.0"
-  DATE = "2016-02-09"
+  VERSION = "1.4.1"
+  DATE = "2022-01-06"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scut",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "homepage": "http://davidtheclark.github.io/scut/",
   "authors": [
     "David Clark <david.dave.clark@gmail.com>"

--- a/src/functions/_em.scss
+++ b/src/functions/_em.scss
@@ -1,5 +1,7 @@
 // Depends on `scut-strip-unit`.
 
+@use "sass:math";
+
 $scut-em-base: 16 !default;
 
 @function scut-em (
@@ -15,7 +17,7 @@ $scut-em-base: 16 !default;
 
   $em-vals: ();
   @each $val in $pixels {
-    $val-in-ems: (scut-strip-unit($val) / $divisor) * 1em;
+    $val-in-ems: math.div(scut-strip-unit($val), $divisor) * 1em;
     $em-vals: append($em-vals, $val-in-ems);
   }
 

--- a/src/functions/_rem.scss
+++ b/src/functions/_rem.scss
@@ -1,5 +1,7 @@
 // Depends on `scut-strip-unit`.
 
+@use "sass:math";
+
 $scut-rem-base: 16 !default;
 
 @function scut-rem (
@@ -8,7 +10,7 @@ $scut-rem-base: 16 !default;
 
   $rem-vals: ();
   @each $val in $pixels {
-    $val-in-rems: scut-strip-unit($val) / $scut-rem-base * 1rem;
+    $val-in-rems: math.div(scut-strip-unit($val), $scut-rem-base) * 1rem;
     $rem-vals: append($rem-vals, $val-in-rems);
   }
 

--- a/src/functions/_strip-unit.scss
+++ b/src/functions/_strip-unit.scss
@@ -1,7 +1,9 @@
+@use "sass:math";
+
 @function scut-strip-unit (
   $num
 ) {
 
-  @return $num / ($num * 0 + 1);
+  @return math.div($num, $num * 0 + 1);
 
 }

--- a/src/general/_circle.scss
+++ b/src/general/_circle.scss
@@ -10,7 +10,7 @@
     // If user wants to inherit the color,
     // take advantage of the fact that border
     // color defaults to the text color of the element.
-    border-width: $size / 2;
+    border-width: $size * 0.5;
     border-style: solid;
     height: 0;
     width: 0;

--- a/src/general/_hd-bp.scss
+++ b/src/general/_hd-bp.scss
@@ -1,8 +1,10 @@
+@use "sass:math";
+
 @mixin scut-hd-bp (
   $ratio: 1.3
 ) {
 
-  @media (-o-min-device-pixel-ratio: ($ratio / 1)),
+  @media (-o-min-device-pixel-ratio: math.div($ratio, 1)),
          (-webkit-min-device-pixel-ratio: $ratio),
          (min-resolution: (round(96 * $ratio) * 1dpi)) {
     @content;

--- a/src/general/_triangle.scss
+++ b/src/general/_triangle.scss
@@ -27,17 +27,17 @@
   @if ($direction == up) or ($direction == down) {
     // For up and down, width gets two borders but height only one,
     // so divide second border-width value by 2
-    $border-widths: $height ($width / 2);
+    $border-widths: $height ($width * 0.5);
   }
   @else if ($direction == right) or ($direction == left) {
     // For right and left, height gets two borders but width only one,
     // so divide first border-width value by 2
-    $border-widths: ($height / 2) $width;
+    $border-widths: ($height * 0.5) $width;
   }
   @else {
     // For right triangles (the rest), both sides get two borders,
     // so divide both by 2
-    $border-widths: ($height / 2) ($width / 2);
+    $border-widths: ($height * 0.5) ($width * 0.5);
   }
 
   border-width: $border-widths;

--- a/src/layout/_center-absolutely.scss
+++ b/src/layout/_center-absolutely.scss
@@ -10,13 +10,13 @@
   @if $width != n {
     width: $width;
     left: 50%;
-    margin-left: (-$width / 2);
+    margin-left: (-$width * 0.5);
   }
 
   @if $height != n {
     height: $height;
     top: 50%;
-    margin-top: (-$height / 2);
+    margin-top: (-$height * 0.5);
   }
 
 }

--- a/src/layout/_ratio-box.scss
+++ b/src/layout/_ratio-box.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @mixin scut-ratio-box (
   $ratio: 1/1
 ) {
@@ -12,7 +14,7 @@
     content: "";
     display: block;
     height: 0;
-    padding-top: (1 / $ratio) * 100%;
+    padding-top: math.div(1, $ratio) * 100%;
   }
 
 }


### PR DESCRIPTION
Referencing issue #209, Sass has [deprecated ](https://sass-lang.com/documentation/breaking-changes/slash-div)the use of slashes for division. This PR is the result of running the [Sass migrator](https://github.com/sass/migrator) to update Scut and resolve this issue.