### PR TITLE
[2.0.0] Fix breaking change: slash as division

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0
+- Fixed [`slash as division`](https://sass-lang.com/documentation/breaking-changes/slash-div) deprecation. Breaks compatibility with LibSass.
+
 ## 1.4.4
 - Remove math.div for LibSass support.
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Scut",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "homepage": "http://ramseyinhouse.github.io/scut/",
   "authors": [
     "David Clark <david.dave.clark@gmail.com>"

--- a/dist/_scut.scss
+++ b/dist/_scut.scss
@@ -1,7 +1,7 @@
 /*
 * Scut, a collection of Sass utilities
 * to ease and improve our implementations of common style-code patterns.
-* v1.4.4
+* v2.0.0
 * Docs at http://ramseyinhouse.github.io/scut
 */
 

--- a/dist/_scut.scss
+++ b/dist/_scut.scss
@@ -5,6 +5,8 @@
 * Docs at http://ramseyinhouse.github.io/scut
 */
 
+@use "sass:math";
+
 @mixin scut-clearfix {
 
   &:after {
@@ -98,7 +100,7 @@
   $num
 ) {
 
-  @return $num / ($num * 0 + 1);
+  @return math.div($num, $num * 0 + 1);
 
 }
 // Depends on `scut-strip-unit`.
@@ -118,7 +120,7 @@ $scut-em-base: 16 !default;
 
   $em-vals: ();
   @each $val in $pixels {
-    $val-in-ems: (scut-strip-unit($val) / $divisor) * 1em;
+    $val-in-ems: math.div(scut-strip-unit($val), $divisor) * 1em;
     $em-vals: append($em-vals, $val-in-ems);
   }
 
@@ -142,7 +144,7 @@ $scut-rem-base: 16 !default;
 
   $rem-vals: ();
   @each $val in $pixels {
-    $val-in-rems: scut-strip-unit($val) / $scut-rem-base * 1rem;
+    $val-in-rems: math.div(scut-strip-unit($val), $scut-rem-base) * 1rem;
     $rem-vals: append($rem-vals, $val-in-rems);
   }
 
@@ -279,7 +281,7 @@ $scut-rem-base: 16 !default;
   $ratio: 1.3
 ) {
 
-  @media (-o-min-device-pixel-ratio: ($ratio / 1)),
+  @media (-o-min-device-pixel-ratio: math.div($ratio, 1)),
          (-webkit-min-device-pixel-ratio: $ratio),
          (min-resolution: (round(96 * $ratio) * 1dpi)) {
     @content;
@@ -1010,7 +1012,7 @@ $scut-rem-base: 16 !default;
 
 }
 @mixin scut-ratio-box (
-  $ratio: 1/1
+  $ratio: math.div(1, 1)
 ) {
 
   overflow: hidden;
@@ -1023,7 +1025,7 @@ $scut-rem-base: 16 !default;
     content: "";
     display: block;
     height: 0;
-    padding-top: (1 / $ratio) * 100%;
+    padding-top: math.div(1, $ratio) * 100%;
   }
 
 }

--- a/docs/content/data.yml
+++ b/docs/content/data.yml
@@ -1,4 +1,4 @@
-"version": "1.4.4"
+"version": "2.0.0"
 github-url: "https://github.com/ramseyinhouse/scut/blob/v"
 github-home: "https://github.com/ramseyinhouse/scut"
 codepen-url: "http://codepen.io/davidtheclark/pen/FhqGc"

--- a/docs/content/example-styles/ratio-box.scss
+++ b/docs/content/example-styles/ratio-box.scss
@@ -1,4 +1,6 @@
 /* import start */
+@use "sass:math";
+
 @import "../../../dist/scut";
 @import "example-variables";
 /* import end */
@@ -24,11 +26,11 @@
 }
 .eg-ratio-3 {
   width: 15em;
-  @include scut-ratio-box(16/9);
+  @include scut-ratio-box(math.div(16, 9));
 }
 .eg-ratio-4 {
   width: 7em;
-  @include scut-ratio-box(16/9);
+  @include scut-ratio-box(math.div(16, 9));
 }
 .eg-ratio-inner {
   position: absolute;

--- a/docs/dev/scss/_examples.scss
+++ b/docs/dev/scss/_examples.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $eg-dark: #002834;
 $eg-light: #9AE9FF;
 $eg-muted: #CCCCCC;
@@ -630,11 +632,11 @@ $scut-em-base: 16;
 }
 .eg-ratio-3 {
   width: 15em;
-  @include scut-ratio-box(16/9);
+  @include scut-ratio-box(math.div(16, 9));
 }
 .eg-ratio-4 {
   width: 7em;
-  @include scut-ratio-box(16/9);
+  @include scut-ratio-box(math.div(16, 9));
 }
 .eg-ratio-inner {
   position: absolute;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-var currentVersion = '1.4.4';
+var currentVersion = '2.0.0';
 
 var moment = require('moment');
 var runSequence = require('run-sequence');

--- a/lib/scut.rb
+++ b/lib/scut.rb
@@ -5,6 +5,6 @@ stylesheets_dir = File.join(base_directory, 'dist')
 Compass::Frameworks.register('Scut', :stylesheets_directory => stylesheets_dir)
 
 module Scut
-  VERSION = "1.4.4"
+  VERSION = "2.0.0"
   DATE = "2022-02-01"
 end

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "gulp-sourcemaps": "^1.3.0",
     "moment": "^2.9.0",
     "run-sequence": "^1.0.2"
+  },
+  "peerDependencies": {
+    "sass": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scut",
-  "version": "1.4.4",
+  "version": "2.0.0",
   "homepage": "http://ramseyinhouse.github.io/scut/",
   "authors": [
     "David Clark <david.dave.clark@gmail.com>",

--- a/src/functions/_em.scss
+++ b/src/functions/_em.scss
@@ -1,5 +1,7 @@
 // Depends on `scut-strip-unit`.
 
+@use "sass:math";
+
 $scut-em-base: 16 !default;
 
 @function scut-em (
@@ -15,7 +17,7 @@ $scut-em-base: 16 !default;
 
   $em-vals: ();
   @each $val in $pixels {
-    $val-in-ems: (scut-strip-unit($val) / $divisor) * 1em;
+    $val-in-ems: math.div(scut-strip-unit($val), $divisor) * 1em;
     $em-vals: append($em-vals, $val-in-ems);
   }
 

--- a/src/functions/_rem.scss
+++ b/src/functions/_rem.scss
@@ -1,5 +1,7 @@
 // Depends on `scut-strip-unit`.
 
+@use "sass:math";
+
 $scut-rem-base: 16 !default;
 
 @function scut-rem (
@@ -8,7 +10,7 @@ $scut-rem-base: 16 !default;
 
   $rem-vals: ();
   @each $val in $pixels {
-    $val-in-rems: scut-strip-unit($val) / $scut-rem-base * 1rem;
+    $val-in-rems: math.div(scut-strip-unit($val), $scut-rem-base) * 1rem;
     $rem-vals: append($rem-vals, $val-in-rems);
   }
 

--- a/src/functions/_strip-unit.scss
+++ b/src/functions/_strip-unit.scss
@@ -1,7 +1,9 @@
+@use "sass:math";
+
 @function scut-strip-unit (
   $num
 ) {
 
-  @return $num / ($num * 0 + 1);
+  @return math.div($num, $num * 0 + 1);
 
 }

--- a/src/general/_hd-bp.scss
+++ b/src/general/_hd-bp.scss
@@ -1,8 +1,10 @@
+@use "sass:math";
+
 @mixin scut-hd-bp (
   $ratio: 1.3
 ) {
 
-  @media (-o-min-device-pixel-ratio: ($ratio / 1)),
+  @media (-o-min-device-pixel-ratio: math.div($ratio, 1)),
          (-webkit-min-device-pixel-ratio: $ratio),
          (min-resolution: (round(96 * $ratio) * 1dpi)) {
     @content;

--- a/src/layout/_ratio-box.scss
+++ b/src/layout/_ratio-box.scss
@@ -1,5 +1,7 @@
+@use "sass:math";
+
 @mixin scut-ratio-box (
-  $ratio: 1/1
+  $ratio: math.div(1, 1)
 ) {
 
   overflow: hidden;
@@ -12,7 +14,7 @@
     content: "";
     display: block;
     height: 0;
-    padding-top: (1 / $ratio) * 100%;
+    padding-top: math.div(1, $ratio) * 100%;
   }
 
 }


### PR DESCRIPTION
Sass has [deprecated ](https://sass-lang.com/documentation/breaking-changes/slash-div)the use of slashes for division. This PR is the result of running the [Sass migrator](https://github.com/sass/migrator) to resolve this issue. It is a major version bump due to incompatibility with LibSass.